### PR TITLE
More flexible shaping spec

### DIFF
--- a/src/build/growth.rs
+++ b/src/build/growth.rs
@@ -1,7 +1,7 @@
 use cgmath::{EuclideanSpace, InnerSpace, Matrix4, MetricSpace, Quaternion, Rotation, Vector3};
 
 use crate::build::growth::Launch::{IdentifiedFace, NamedFace, Seeded};
-use crate::build::tenscript::{BuildPhase, FabricPlan, FaceName, PostShapeOperation, Seed, ShapePhase, ShaperSpec, Spin};
+use crate::build::tenscript::{BuildPhase, FabricPlan, FaceName, Seed, ShapePhase, ShapeOperation, Spin};
 use crate::build::tenscript::BuildNode;
 use crate::build::tenscript::BuildNode::{Branch, Face, Grow, Mark};
 use crate::build::tenscript::FaceName::Apos;
@@ -98,8 +98,8 @@ impl Growth {
     }
 
     pub fn create_shapers(&mut self, fabric: &mut Fabric) {
-        let ShapePhase { shaper_specs, .. } = &self.plan.shape_phase;
-        for shaper_spec in shaper_specs {
+        let ShapePhase { operations } = &self.plan.shape_phase;
+        for shaper_spec in operations {
             self.shapers.extend(self.attach_shapers_for(fabric, shaper_spec))
         }
         self.marks.clear();
@@ -230,10 +230,10 @@ impl Growth {
         fabric.apply_matrix4(rotation);
     }
 
-    fn attach_shapers_for(&self, fabric: &mut Fabric, shaper_spec: &ShaperSpec) -> Vec<Shaper> {
+    fn attach_shapers_for(&self, fabric: &mut Fabric, shaper_spec: &ShapeOperation) -> Vec<Shaper> {
         let mut shapers: Vec<Shaper> = vec![];
         match shaper_spec {
-            ShaperSpec::Join { mark_name } => {
+            ShapeOperation::Join { mark_name } => {
                 let faces = self.marked_faces(mark_name);
                 let joints = self.marked_middle_joints(fabric, &faces);
                 match (joints.as_slice(), faces.as_slice()) {
@@ -244,7 +244,7 @@ impl Growth {
                     _ => unimplemented!()
                 }
             }
-            ShaperSpec::Distance { mark_name, distance_factor } => {
+            ShapeOperation::Distance { mark_name, distance_factor } => {
                 let faces = self.marked_faces(mark_name);
                 let joints = self.marked_middle_joints(fabric, &faces);
                 match (joints.as_slice(), faces.as_slice()) {
@@ -256,6 +256,9 @@ impl Growth {
                     _ => println!("Wrong number of faces for mark {mark_name}"),
                 }
             }
+            ShapeOperation::Wait { .. } => {}
+            ShapeOperation::Vulcanize => {}
+            ShapeOperation::ReplaceFaces => {}
         }
         shapers
     }

--- a/src/build/tenscript/bootstrap.scm
+++ b/src/build/tenscript/bootstrap.scm
@@ -10,8 +10,8 @@
       (face A+ (grow 3))
       (face B+ (grow 3))))
   (shape
-    (finally :bow-tie-pulls)
-    (finally :faces-to-triangles)))
+    (vulcanize)
+    (replace-faces)))
 ;;;Flagellum
 (fabric
   (build
@@ -26,8 +26,8 @@
         (face D- (grow 11 (scale .92) (mark :halo-end))))))
   (shape
     (join :halo-end)
-    (finally :bow-tie-pulls)
-    (finally :faces-to-triangles)))
+    (vulcanize)
+    (replace-faces)))
 ;;;Headless Hug
 (fabric
   (build
@@ -52,6 +52,6 @@
     (space :legs .3)
     (space :hands .01)
     (space :shoulders .05)
-    (finally :bow-tie-pulls)
-    (finally :faces-to-triangles)))
+    (vulcanize)
+    (replace-faces)))
 

--- a/src/build/tenscript/bootstrap.scm
+++ b/src/build/tenscript/bootstrap.scm
@@ -49,10 +49,11 @@
             (face D+ (grow "....X..." (scale .93) (mark :hands)))
             )))))
   (shape
-    (countdown 2000
+    (countdown 25000
       (space :legs .3)
       (space :hands .01)
       (space :shoulders .05))
-    (vulcanize)
+    (countdown 10000 (vulcanize))
+    (remove-shapers)
     (replace-faces)))
 

--- a/src/build/tenscript/bootstrap.scm
+++ b/src/build/tenscript/bootstrap.scm
@@ -49,9 +49,10 @@
             (face D+ (grow "....X..." (scale .93) (mark :hands)))
             )))))
   (shape
-    (space :legs .3)
-    (space :hands .01)
-    (space :shoulders .05)
+    (countdown 2000
+      (space :legs .3)
+      (space :hands .01)
+      (space :shoulders .05))
     (vulcanize)
     (replace-faces)))
 

--- a/src/build/tenscript/mod.rs
+++ b/src/build/tenscript/mod.rs
@@ -119,21 +119,17 @@ pub struct BuildPhase {
 }
 
 #[derive(Debug, Clone)]
-pub enum ShaperSpec {
+pub enum ShapeOperation {
     Join { mark_name: String },
     Distance { mark_name: String, distance_factor: f32 },
-}
-
-#[derive(Debug, Clone)]
-pub enum PostShapeOperation {
-    BowTiePulls,
-    FacesToTriangles,
+    Wait { count: usize },
+    Vulcanize,
+    ReplaceFaces,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct ShapePhase {
-    pub shaper_specs: Vec<ShaperSpec>,
-    pub post_shape_operations: Vec<PostShapeOperation>,
+    pub operations: Vec<ShapeOperation>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/build/tenscript/mod.rs
+++ b/src/build/tenscript/mod.rs
@@ -126,6 +126,7 @@ pub enum ShapeOperation {
     },
     Join { mark_name: String },
     Distance { mark_name: String, distance_factor: f32 },
+    RemoveShapers { mark_names: Vec<String> },
     Vulcanize,
     ReplaceFaces,
 }

--- a/src/build/tenscript/mod.rs
+++ b/src/build/tenscript/mod.rs
@@ -120,9 +120,12 @@ pub struct BuildPhase {
 
 #[derive(Debug, Clone)]
 pub enum ShapeOperation {
+    Countdown {
+        count: usize,
+        operations: Vec<ShapeOperation>,
+    },
     Join { mark_name: String },
     Distance { mark_name: String, distance_factor: f32 },
-    Wait { count: usize },
     Vulcanize,
     ReplaceFaces,
 }
@@ -157,7 +160,10 @@ pub fn fabric_plan(plan_name: &str) -> FabricPlan {
     let Some((_, code)) = plans.iter().find(|&(name, _)| *name == plan_name) else {
         panic!("{plan_name} not found");
     };
-    FabricPlan::from_tenscript(code.as_str()).unwrap()
+    match FabricPlan::from_tenscript(code.as_str()) {
+        Ok(plan) => plan,
+        Err(error) => panic!("error parsing fabric plan: {error}")
+    }
 }
 
 #[cfg(test)]

--- a/src/build/tenscript/parser.rs
+++ b/src/build/tenscript/parser.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::result_large_err)]
 
+use std::fmt::{Display, Formatter};
+
 use pest::error::Error;
 use pest::iterators::Pair;
 use pest::Parser;
@@ -16,6 +18,16 @@ pub enum ParseError {
     Syntax(String),
     Pest(Error<Rule>),
 }
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::Syntax(message) => write!(f, "syntax error: {message}"),
+            ParseError::Pest(error) => write!(f, "pest parse error: {error}"),
+        }
+    }
+}
+
 
 impl FabricPlan {
     pub fn from_tenscript(source: &str) -> Result<Self, ParseError> {
@@ -54,35 +66,42 @@ impl FabricPlan {
     }
 
     fn parse_shape_phase(shape_phase_pair: Pair<Rule>) -> Result<ShapePhase, ParseError> {
-        let mut shape_phase = ShapePhase::default();
-        for pair in shape_phase_pair.into_inner() {
-            match pair.as_rule() {
-                Rule::space_statement => {
-                    let [mark_name, distance_string] = pair.into_inner().next_chunk().unwrap().map(|p| p.as_str());
-                    let distance_factor = distance_string.parse().unwrap();
-                    shape_phase.operations.push(ShapeOperation::Distance {
-                        mark_name: mark_name[1..].into(),
-                        distance_factor,
-                    })
+        let operations = shape_phase_pair
+            .into_inner()
+            .map(Self::parse_shape_operation)
+            .collect();
+        Ok(ShapePhase { operations })
+    }
+
+    fn parse_shape_operation(pair: Pair<Rule>) -> ShapeOperation {
+        let rule = pair.as_rule();
+        match rule {
+            Rule::basic_shape_operation | Rule::shape_operation =>
+                Self::parse_shape_operation(pair.into_inner().next().unwrap()),
+            Rule::space => {
+                let [mark_name, distance_string] = pair.into_inner().next_chunk().unwrap().map(|p| p.as_str());
+                let distance_factor = distance_string.parse().unwrap();
+                ShapeOperation::Distance {
+                    mark_name: mark_name[1..].into(),
+                    distance_factor,
                 }
-                Rule::join_statement => {
-                    let mark_name = pair.into_inner().next().unwrap().as_str();
-                    shape_phase.operations.push(ShapeOperation::Join { mark_name: mark_name[1..].into() })
-                }
-                Rule::wait_statement => {
-                    let count = pair.into_inner().next().unwrap().as_str().parse().unwrap();
-                    shape_phase.operations.push(ShapeOperation::Wait { count });
-                }
-                Rule::remove_faces_statement => {
-                    shape_phase.operations.push(ShapeOperation::ReplaceFaces);
-                }
-                Rule::vulcanize_statement => {
-                    shape_phase.operations.push(ShapeOperation::Vulcanize);
-                }
-                _ => unreachable!("shape phase")
             }
+            Rule::join => {
+                let mark_name = pair.into_inner().next().unwrap().as_str();
+                ShapeOperation::Join { mark_name: mark_name[1..].into() }
+            }
+            Rule::countdown_block => {
+                let mut inner = pair.into_inner();
+                let count = inner.next().unwrap().as_str().parse().unwrap();
+                let operations = inner.map(Self::parse_shape_operation).collect();
+                ShapeOperation::Countdown { count, operations }
+            }
+            Rule::replace_faces =>
+                ShapeOperation::ReplaceFaces,
+            Rule::vulcanize =>
+                ShapeOperation::Vulcanize,
+            _ => unreachable!("shape phase: {pair}")
         }
-        Ok(shape_phase)
     }
 
     fn parse_build_phase(build_phase_pair: Pair<Rule>) -> Result<BuildPhase, ParseError> {

--- a/src/build/tenscript/parser.rs
+++ b/src/build/tenscript/parser.rs
@@ -96,6 +96,10 @@ impl FabricPlan {
                 let operations = inner.map(Self::parse_shape_operation).collect();
                 ShapeOperation::Countdown { count, operations }
             }
+            Rule::remove_shapers => {
+                let mark_names = pair.into_inner().map(|p| p.as_str()[1..].into()).collect();
+                ShapeOperation::RemoveShapers { mark_names }
+            }
             Rule::replace_faces =>
                 ShapeOperation::ReplaceFaces,
             Rule::vulcanize =>

--- a/src/build/tenscript/tenscript.pest
+++ b/src/build/tenscript/tenscript.pest
@@ -4,8 +4,7 @@
 //
 
 fabric_plan = {
-    "(" ~
-    "fabric" ~
+    "(" ~ "fabric" ~
     surface? ~
     build? ~
     shape? ~
@@ -13,37 +12,41 @@ fabric_plan = {
 }
 
 shape = {
-    "(" ~
-    "shape" ~
-    (space_statement | join_statement | finally_statement)+ ~
+    "(" ~ "shape" ~
+    shape_operation+ ~
     ")"
+}
+
+shape_operation = {
+    space_statement |
+    join_statement |
+    vulcanize_statement |
+    remove_faces_statement |
+    wait_statement
 }
 
 space_statement = {
-    "(" ~
-    "space" ~
-    atom ~
-    number ~
-    ")"
+    "(" ~ "space" ~ atom ~ number ~ ")"
 }
 
 join_statement = {
-    "(" ~
-    "join" ~
-    atom ~
-    ")"
+    "(" ~ "join" ~ atom ~ ")"
 }
 
-finally_statement = {
-    "(" ~
-    "finally" ~
-    atom ~
-    ")"
+vulcanize_statement = {
+    "(" ~ "vulcanize" ~ ")"
+}
+
+remove_faces_statement = {
+    "(" ~ "remove-faces" ~ ")"
+}
+
+wait_statement = {
+    "(" ~ "wait" ~ integer ~ ")"
 }
 
 build = {
-    "(" ~
-    "build" ~
+    "(" ~ "build" ~
     seed? ~
     build_node? ~
     ")"
@@ -54,8 +57,7 @@ build_node = {
 }
 
 face = {
-    "(" ~
-    "face" ~
+    "(" ~ "face" ~
     face_name ~
     build_node ~
     ")"
@@ -69,8 +71,7 @@ face_name = {
 }
 
 grow = {
-    "(" ~
-    "grow" ~
+    "(" ~ "grow" ~
     (integer | forward) ~
     scale? ~
     build_node? ~
@@ -78,15 +79,11 @@ grow = {
 }
 
 mark = {
-    "(" ~
-    "mark" ~
-    atom ~
-    ")"
+    "(" ~ "mark" ~ atom ~ ")"
 }
 
 branch = {
-    "(" ~
-    "branch" ~
+    "(" ~ "branch" ~
     build_node+ ~
     ")"
 }

--- a/src/build/tenscript/tenscript.pest
+++ b/src/build/tenscript/tenscript.pest
@@ -13,36 +13,42 @@ fabric_plan = {
 
 shape = {
     "(" ~ "shape" ~
-    shape_operation+ ~
+        shape_operation+ ~
     ")"
 }
 
-shape_operation = {
-    space_statement |
-    join_statement |
-    vulcanize_statement |
-    remove_faces_statement |
-    wait_statement
+basic_shape_operation = {
+    space |
+    join |
+    vulcanize |
+    replace_faces
 }
 
-space_statement = {
+shape_operation = {
+    basic_shape_operation |
+    countdown_block
+}
+
+countdown_block = {
+    "(" ~ "countdown" ~ integer ~
+        basic_shape_operation+ ~
+    ")"
+}
+
+space = {
     "(" ~ "space" ~ atom ~ number ~ ")"
 }
 
-join_statement = {
+join = {
     "(" ~ "join" ~ atom ~ ")"
 }
 
-vulcanize_statement = {
+vulcanize = {
     "(" ~ "vulcanize" ~ ")"
 }
 
-remove_faces_statement = {
-    "(" ~ "remove-faces" ~ ")"
-}
-
-wait_statement = {
-    "(" ~ "wait" ~ integer ~ ")"
+replace_faces = {
+    "(" ~ "replace-faces" ~ ")"
 }
 
 build = {

--- a/src/build/tenscript/tenscript.pest
+++ b/src/build/tenscript/tenscript.pest
@@ -21,6 +21,7 @@ basic_shape_operation = {
     space |
     join |
     vulcanize |
+    remove_shapers |
     replace_faces
 }
 
@@ -41,6 +42,10 @@ space = {
 
 join = {
     "(" ~ "join" ~ atom ~ ")"
+}
+
+remove_shapers = {
+    "(" ~ "remove-shapers" ~ atom* ~ ")"
 }
 
 vulcanize = {


### PR DESCRIPTION
- Extend Tenscript grammar to enable arbitrary sequence of shape operations inside `(shape ..)`. Rename existing operations to clean up.
- Add new `(countdown ..)` block which takes a number of iterations to wait for and executes operations contained within in parallel
- Remove lots of stages in the PlanRunner, made redundant by custom countdowns in the new shaping spec
