### PR TITLE
Parse bricks in tenscript

### DIFF
--- a/src/build/brick.rs
+++ b/src/build/brick.rs
@@ -18,10 +18,11 @@ pub enum Axis {
 impl Axis {
     pub fn from_pair(pair: Pair<Rule>) -> Self {
         match pair.as_rule() {
+            Rule::axis => Self::from_pair(pair.into_inner().next().unwrap()),
             Rule::axis_x => Axis::X,
             Rule::axis_y => Axis::Y,
             Rule::axis_z => Axis::Z,
-            _ => unreachable!(),
+            _ => unreachable!("{:?}", pair.as_rule()),
         }
     }
 }
@@ -29,6 +30,7 @@ impl Axis {
 impl Spin {
     pub fn from_pair(pair: Pair<Rule>) -> Self {
         match pair.as_rule() {
+            Rule::chirality => Self::from_pair(pair.into_inner().next().unwrap()),
             Rule::left => Left,
             Rule::right => Right,
             _ => unreachable!(),

--- a/src/build/brick.rs
+++ b/src/build/brick.rs
@@ -1,13 +1,56 @@
 use cgmath::{Point3, point3};
 use clap::ValueEnum;
+use pest::iterators::Pair;
 
 use crate::build::tenscript::{FaceName, Spin};
+use crate::build::tenscript::fabric_plan::Rule;
 use crate::build::tenscript::Spin::{Left, Right};
 use crate::fabric::interval::Role;
 use crate::fabric::interval::Role::{Pull, Push};
 
+pub enum Axis {
+    X,
+    Y,
+    Z,
+}
+
+pub enum Chirality {
+    Left,
+    Right,
+}
+
+pub struct PushDef {
+    pub axis: Axis,
+    pub ideal: f32,
+    pub alpha_name: String,
+    pub omega_name: String,
+}
+
+pub struct PullDef {
+    pub ideal: f32,
+    pub alpha_name: String,
+    pub omega_name: String,
+}
+
+pub struct Face {
+    pub chirality: Chirality,
+    pub joint_names: [String; 3],
+    pub name: String,
+}
+
+pub struct Prototype {
+    pub pushes: Vec<PushDef>,
+    pub pulls: Vec<PullDef>,
+    pub faces: Vec<Face>,
+}
+
+pub struct Definition {
+    pub proto: Prototype,
+    pub baked: Baked,
+}
+
 #[derive(Debug, Clone)]
-pub struct Brick {
+pub struct Baked {
     pub joints: Vec<Point3<f32>>,
     pub intervals: Vec<(usize, usize, Role, f32)>,
     pub faces: Vec<([usize; 3], FaceName, Spin)>,
@@ -24,10 +67,12 @@ pub enum BrickName {
     RightMitosis,
 }
 
-impl Brick {
-    pub fn new(name: BrickName) -> Brick {
+impl Baked {
+    pub fn from_pair(pair: Pair<Rule>)
+
+    pub fn new(name: BrickName) -> Baked {
         match name {
-            BrickName::LeftTwist => Brick {
+            BrickName::LeftTwist => Baked {
                 joints: vec![
                     point3(-0.5000, 0.0000, 0.8660),
                     point3(-0.5000, 0.0000, -0.8660),
@@ -51,7 +96,7 @@ impl Brick {
                     ([2, 1, 0], FaceName(0), Left),
                 ],
             },
-            BrickName::RightTwist => Brick {
+            BrickName::RightTwist => Baked {
                 joints: vec![
                     point3(-0.5000, -0.0000, 0.8660),
                     point3(-0.5000, 0.0000, -0.8660),
@@ -75,7 +120,7 @@ impl Brick {
                     ([3, 4, 5], FaceName(1), Right),
                 ],
             },
-            BrickName::LeftOmniTwist => Brick {
+            BrickName::LeftOmniTwist => Baked {
                 joints: vec![
                     point3(-0.0000, 0.0001, 0.0000),
                     point3(1.0000, 0.0000, 0.0000),
@@ -117,7 +162,7 @@ impl Brick {
                     ([14, 11, 6], FaceName(1), Left),
                 ],
             },
-            BrickName::RightOmniTwist => Brick {
+            BrickName::RightOmniTwist => Baked {
                 joints: vec![
                     point3(0.0000, 0.0002, 0.0000),
                     point3(1.0000, 0.0000, -0.0000),
@@ -159,7 +204,7 @@ impl Brick {
                     ([7, 15, 10], FaceName(1), Right),
                 ],
             },
-            BrickName::LeftMitosis => Brick {
+            BrickName::LeftMitosis => Baked {
                 joints: vec![
                     point3(1.8948, 1.4897, -0.0230),
                     point3(-0.5230, 0.0000, -0.8371),
@@ -218,7 +263,7 @@ impl Brick {
                     ([15, 4, 9], FaceName(4), Left),
                 ],
             },
-            BrickName::RightMitosis => Brick {
+            BrickName::RightMitosis => Baked {
                 joints: vec![
                     point3(-0.5230, 0.0000, 0.8371),
                     point3(1.8948, 1.4897, 0.0230),

--- a/src/build/brick_proto.rs
+++ b/src/build/brick_proto.rs
@@ -171,17 +171,17 @@ impl Baked {
                 let [
                 (left_front, left_back),
                 (middle_front, middle_back),
-                (right_front, right_back)
+                (right_front, right_back),
                 ] = p.x(normal_push_length);
                 let [
                 (front_left_bottom, front_left_top),
                 (front_right_bottom, front_right_top),
                 (back_left_bottom, back_left_top),
-                (back_right_bottom, back_right_top)
+                (back_right_bottom, back_right_top),
                 ] = p.y(normal_push_length);
                 let [
                 (top_left, top_right),
-                (bottom_left, bottom_right)
+                (bottom_left, bottom_right),
                 ] = p.z(normal_push_length * 2.0);
                 p.pull(2.5, &[
                     (middle_front, front_left_bottom),

--- a/src/build/brick_proto.rs
+++ b/src/build/brick_proto.rs
@@ -3,14 +3,14 @@ use std::f32::consts::PI;
 use cgmath::{EuclideanSpace, Point3, SquareMatrix, Vector3};
 use cgmath::num_traits::abs;
 
-use crate::build::brick::{Brick, BrickName};
+use crate::build::brick::{Baked, BrickName};
 use crate::build::tenscript::{FaceName, Spin};
 use crate::build::tenscript::Spin::{Left, Right};
 use crate::fabric::{Fabric, Link, UniqueId};
 use crate::fabric::interval::Interval;
 use crate::fabric::joint::Joint;
 
-impl Brick {
+impl Baked {
     pub const TARGET_FACE_STRAIN: f32 = 0.1;
 
     pub fn into_code(self) -> String {
@@ -43,7 +43,7 @@ impl Brick {
     }
 }
 
-impl TryFrom<(Fabric, UniqueId)> for Brick {
+impl TryFrom<(Fabric, UniqueId)> for Baked {
     type Error = String;
 
     fn try_from((fabric, face_id): (Fabric, UniqueId)) -> Result<Self, String> {
@@ -51,7 +51,7 @@ impl TryFrom<(Fabric, UniqueId)> for Brick {
         let face = fabric.face(face_id);
         fabric.apply_matrix4(face.vector_space(&fabric, false).invert().unwrap());
         let joint_incident = fabric.joint_incident();
-        let target_face_strain = Brick::TARGET_FACE_STRAIN;
+        let target_face_strain = Baked::TARGET_FACE_STRAIN;
         for face in fabric.faces.values() {
             let strain = face.strain(&fabric);
             if abs(strain - target_face_strain) > 0.0001 {
@@ -76,7 +76,7 @@ impl TryFrom<(Fabric, UniqueId)> for Brick {
     }
 }
 
-impl Brick {
+impl Baked {
     pub fn prototype(name: BrickName) -> (Fabric, UniqueId) {
         match name {
             BrickName::LeftTwist | BrickName::RightTwist => {

--- a/src/build/tenscript/bootstrap.scm
+++ b/src/build/tenscript/bootstrap.scm
@@ -61,19 +61,19 @@
   (brick
     (name "Mitosis")
     (proto
-      (pushes X 3 .467
+      (pushes X 3.467
         (push :left_front :left_back)
         (push :middle_front :middle_back)
         (push :right_front :right_back))
-      (pushes Y 3 .467
+      (pushes Y 3.467
         (push :front_left_bottom :front_left_top)
         (push :front_right_bottom :front_right_top)
         (push :back_left_bottom :back_left_top)
         (push :back_right_bottom :back_right_top))
-      (pushes Z 6 .934
+      (pushes Z 6.934
         (push :top_left :top_right)
         (push :bottom_left :bottom_right))
-      (pulls 2 .5
+      (pulls 2.5
         (pull :middle_front :front_left_bottom)
         (pull :middle_front :front_left_top)
         (pull :middle_front :front_right_bottom)

--- a/src/build/tenscript/bootstrap.scm
+++ b/src/build/tenscript/bootstrap.scm
@@ -57,5 +57,38 @@
         (space :shoulders .05))
       (countdown 10000 (vulcanize))
       (remove-shapers)
-      (replace-faces))))
+      (replace-faces)))
+  (brick
+    (name "Mitosis")
+    (proto
+      (pushes X 3 .467
+        (push :left_front :left_back)
+        (push :middle_front :middle_back)
+        (push :right_front :right_back))
+      (pushes Y 3 .467
+        (push :front_left_bottom :front_left_top)
+        (push :front_right_bottom :front_right_top)
+        (push :back_left_bottom :back_left_top)
+        (push :back_right_bottom :back_right_top))
+      (pushes Z 6 .934
+        (push :top_left :top_right)
+        (push :bottom_left :bottom_right))
+      (pulls 2 .5
+        (pull :middle_front :front_left_bottom)
+        (pull :middle_front :front_left_top)
+        (pull :middle_front :front_right_bottom)
+        (pull :middle_front :front_right_top)
+        (pull :middle_back :back_left_bottom)
+        (pull :middle_back :back_left_top)
+        (pull :middle_back :back_right_bottom)
+        (pull :middle_back :back_right_top))
+      (faces
+        (left :top_left :left_back :back_left_top F0)
+        (left :bottom_left :left_front :front_left_bottom F1)
+        (left :top_right :right_front :front_right_top F2)
+        (left :bottom_right :right_back :back_right_bottom F3)
+        (right :top_left :front_left_top :left_front F3)
+        (right :bottom_left :back_left_bottom :left_back F5)
+        (right :top_right :back_right_top :right_back F6)
+        (right :bottom_right :front_right_bottom :right_front F7)))))
 

--- a/src/build/tenscript/bootstrap.scm
+++ b/src/build/tenscript/bootstrap.scm
@@ -1,4 +1,4 @@
-(fabrics
+(collection
   (fabric
     (name "Seed")
     (build

--- a/src/build/tenscript/build_phase.rs
+++ b/src/build/tenscript/build_phase.rs
@@ -1,11 +1,11 @@
 use cgmath::{EuclideanSpace, InnerSpace, Matrix4, Quaternion, Rotation, Vector3};
 use pest::iterators::Pair;
-use crate::build::brick::BrickName;
 
+use crate::build::brick::BrickName;
 use crate::build::tenscript::{FaceMark, FaceName, Spin};
 use crate::build::tenscript::build_phase::BuildNode::{*};
 use crate::build::tenscript::build_phase::Launch::{*};
-use crate::build::tenscript::fabric_plan::Rule;
+use crate::build::tenscript::Rule;
 use crate::fabric::{Fabric, UniqueId};
 
 #[derive(Debug, Default, Clone)]

--- a/src/build/tenscript/fabric_plan.rs
+++ b/src/build/tenscript/fabric_plan.rs
@@ -1,10 +1,8 @@
 #![allow(clippy::result_large_err)]
 
 use std::collections::HashSet;
-use std::fmt::Display;
 
 use pest::iterators::Pair;
-use pest::Parser;
 
 use crate::build::tenscript::{BuildPhase, Collection, parse_name, ParseError, Rule, SurfaceCharacterSpec};
 use crate::build::tenscript::build_phase::BuildNode;
@@ -50,7 +48,7 @@ impl FabricPlan {
                 Rule::shape => {
                     plan.shape_phase = ShapePhase::from_pair(pair);
                 }
-                _ => unreachable!("fabric plan"),
+                _ => unreachable!("fabric plan {:?}", pair.as_rule()),
             }
         }
         Self::validate_fabric_plan(&plan)?;
@@ -95,16 +93,5 @@ impl FabricPlan {
             return Err(ParseError::Invalid(format!("undefined marks in shape phase: {}", undefined_marks.join(", "))));
         }
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::build::tenscript::fabric_plan::FabricPlan;
-
-    #[test]
-    fn parse_test() {
-        let plans = FabricPlan::bootstrap();
-        println!("{plans:?}")
     }
 }

--- a/src/build/tenscript/mod.rs
+++ b/src/build/tenscript/mod.rs
@@ -87,10 +87,10 @@ pub struct FaceMark {
     mark_name: String,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct Collection {
-    fabrics: Vec<FabricPlan>,
-    bricks: Vec<BrickDefinition>,
+    pub(crate) fabrics: Vec<FabricPlan>,
+    pub(crate) bricks: Vec<BrickDefinition>,
 }
 
 impl Collection {
@@ -122,13 +122,11 @@ impl Collection {
         for definition in pair.into_inner() {
             match definition.as_rule() {
                 Rule::fabric_plan => {
-                    let fabric_plan_pair = definition.into_inner().next().unwrap();
-                    let fabric_plan = FabricPlan::from_pair(fabric_plan_pair)?;
+                    let fabric_plan = FabricPlan::from_pair(definition)?;
                     collection.fabrics.push(fabric_plan);
                 }
-                Rule::brick => {
-                    let brick_pair = definition.into_inner().next().unwrap();
-                    let brick = BrickDefinition::from_pair(brick_pair)?;
+                Rule::brick_definition => {
+                    let brick = BrickDefinition::from_pair(definition)?;
                     collection.bricks.push(brick);
                 }
                 _ => unreachable!()
@@ -146,4 +144,15 @@ pub fn parse_name(pair: Pair<Rule>) -> String {
 
 pub fn parse_atom(pair: Pair<Rule>) -> String {
     pair.as_str()[1..].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::build::tenscript::Collection;
+
+    #[test]
+    fn parse_test() {
+        let plans = Collection::bootstrap();
+        println!("{plans:?}")
+    }
 }

--- a/src/build/tenscript/mod.rs
+++ b/src/build/tenscript/mod.rs
@@ -2,6 +2,10 @@
 
 use std::fmt::{Display, Formatter};
 
+use pest::error::Error;
+use pest::Parser;
+use pest_derive::Parser;
+
 pub use fabric_plan::FabricPlan;
 
 use crate::build::tenscript::build_phase::BuildPhase;
@@ -11,6 +15,25 @@ pub mod fabric_plan;
 pub mod plan_runner;
 mod shape_phase;
 mod build_phase;
+
+#[derive(Parser)]
+#[grammar = "build/tenscript/tenscript.pest"] // relative to src
+struct TenscriptParser;
+
+#[derive(Debug)]
+pub enum ParseError {
+    Pest(Error<Rule>),
+    Invalid(String),
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::Pest(error) => write!(f, "parse error: {error}"),
+            ParseError::Invalid(warning) => write!(f, "warning: {warning}"),
+        }
+    }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct FaceName(pub usize);
@@ -58,4 +81,11 @@ impl Spin {
 pub struct FaceMark {
     face_id: UniqueId,
     mark_name: String,
+}
+
+mod brick {}
+
+pub struct Collection {
+    fabric_plans: Vec<FabricPlan>,
+    bricks: Vec<brick::Definition>,
 }

--- a/src/build/tenscript/mod.rs
+++ b/src/build/tenscript/mod.rs
@@ -143,7 +143,11 @@ pub fn parse_name(pair: Pair<Rule>) -> String {
 }
 
 pub fn parse_atom(pair: Pair<Rule>) -> String {
-    pair.as_str()[1..].to_string()
+    let string = pair.as_str();
+    string
+        .strip_prefix(':')
+        .unwrap_or(string)
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/build/tenscript/shape_phase.rs
+++ b/src/build/tenscript/shape_phase.rs
@@ -2,7 +2,6 @@ use std::default::Default;
 
 use cgmath::MetricSpace;
 use pest::iterators::Pair;
-use pest::Parser;
 
 use crate::build::tenscript::FaceMark;
 use crate::build::tenscript::Rule;

--- a/src/build/tenscript/shape_phase.rs
+++ b/src/build/tenscript/shape_phase.rs
@@ -2,9 +2,10 @@ use std::default::Default;
 
 use cgmath::MetricSpace;
 use pest::iterators::Pair;
+use pest::Parser;
 
-use crate::build::tenscript::fabric_plan::Rule;
 use crate::build::tenscript::FaceMark;
+use crate::build::tenscript::Rule;
 use crate::build::tenscript::shape_phase::Command::{*};
 use crate::fabric::{Fabric, Link, UniqueId};
 

--- a/src/build/tenscript/tenscript.pest
+++ b/src/build/tenscript/tenscript.pest
@@ -1,5 +1,5 @@
-fabrics =
-    { "(" ~ "fabrics" ~ fabric_plan* ~ ")" }
+collection =
+    { "(" ~ "collection" ~ fabric_plan* ~ brick* ~ ")" }
 
 fabric_plan =
     { "(" ~ "fabric" ~ name ~ surface? ~ build? ~ shape? ~ ")" }
@@ -51,9 +51,9 @@ surface_character =
     { ":bouncy" | ":frozen" | ":sticky" }
 
 brick =
-    { "(" ~ "brick" ~ name ~ brick_baked ~ brick_proto ~ ")" }
+    { "(" ~ "brick" ~ name ~ brick_proto ~ brick_baked? ~ ")" }
 brick_proto =
-    { "(" ~ "proto" ~ pushes_proto+ ~ pulls_proto+ ~ ")" }
+    { "(" ~ "proto" ~ pushes_proto+ ~ pulls_proto+ ~ faces_proto+ ~ ")" }
 pushes_proto = // axis, ideal
     { "(" ~ "pushes" ~ axis ~ float ~ push_proto+ ~ ")" }
 axis =
@@ -64,6 +64,8 @@ pulls_proto = // ideal
     { "(" ~ "pulls" ~ float ~ pull_proto+ ~ ")" }
 pull_proto = // alpha, omega
     { "(" ~ "pull" ~ atom ~ atom ~ ")" }
+faces_proto =
+    { "(" ~ "faces" ~ (left_proto | right_proto)+ ~ ")" }
 left_proto = // a, b, c, name
     { "(" ~ "left" ~ atom ~ atom ~ atom ~ atom ~ ")" }
 right_proto = // a, b, c, name
@@ -83,7 +85,8 @@ right_baked = // a, b, c, name
 
 face_name = @{"F" ~ integer}
 ident = @{ XID_START ~ (XID_CONTINUE | "-")* }
-atom = @{ ":" ~ ident }
+ident_uppercase = @{ ASCII_ALPHA_UPPER ~ (XID_CONTINUE | "-")* }
+atom = @{ (":" ~ ident) | ident_uppercase }
 float = @{ (integer? ~ "." ~ mantissa) | integer }
 integer = @{ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT+ | ASCII_DIGIT }
 mantissa = @{ ASCII_DIGIT+ }

--- a/src/build/tenscript/tenscript.pest
+++ b/src/build/tenscript/tenscript.pest
@@ -56,8 +56,10 @@ brick_proto =
     { "(" ~ "proto" ~ pushes_proto+ ~ pulls_proto+ ~ faces_proto+ ~ ")" }
 pushes_proto = // axis, ideal
     { "(" ~ "pushes" ~ axis ~ float ~ push_proto+ ~ ")" }
-axis =
-    { ":x-axis" | ":y-axis" | ":z-axis" }
+axis = { axis_x | axis_y | axis_z }
+axis_x = { ":x-axis" | "X" }
+axis_y = { ":y-axis" | "Y" }
+axis_z = { ":z-axis" | "Z" }
 push_proto = // alpha, omega
     { "(" ~ "push" ~ atom ~ atom ~ ")" }
 pulls_proto = // ideal
@@ -65,11 +67,12 @@ pulls_proto = // ideal
 pull_proto = // alpha, omega
     { "(" ~ "pull" ~ atom ~ atom ~ ")" }
 faces_proto =
-    { "(" ~ "faces" ~ (left_proto | right_proto)+ ~ ")" }
-left_proto = // a, b, c, name
-    { "(" ~ "left" ~ atom ~ atom ~ atom ~ atom ~ ")" }
-right_proto = // a, b, c, name
-    { "(" ~ "right" ~ atom ~ atom ~ atom ~ atom ~ ")" }
+    { "(" ~ "faces" ~ face_proto+ ~ ")" }
+chirality = { left | right }
+left = { "left" }
+right = { "right" }
+face_proto = // a, b, c, name
+    { "(" ~ chirality ~ atom ~ atom ~ atom ~ atom ~ ")" }
 brick_baked =
     { "(" ~ "baked" ~ joint_baked+ ~ (push_baked | pull_baked)+ ~ (left_baked | right_baked)+ ~ ")" }
 joint_baked = // x, y, z

--- a/src/build/tenscript/tenscript.pest
+++ b/src/build/tenscript/tenscript.pest
@@ -1,5 +1,5 @@
 collection =
-    { "(" ~ "collection" ~ fabric_plan* ~ brick* ~ ")" }
+    { "(" ~ "collection" ~ fabric_plan* ~ brick_definition* ~ ")" }
 
 fabric_plan =
     { "(" ~ "fabric" ~ name ~ surface? ~ build? ~ shape? ~ ")" }
@@ -50,7 +50,7 @@ surface =
 surface_character =
     { ":bouncy" | ":frozen" | ":sticky" }
 
-brick =
+brick_definition =
     { "(" ~ "brick" ~ name ~ brick_proto ~ brick_baked? ~ ")" }
 brick_proto =
     { "(" ~ "proto" ~ pushes_proto+ ~ pulls_proto+ ~ faces_proto+ ~ ")" }
@@ -74,17 +74,16 @@ right = { "right" }
 face_proto = // a, b, c, name
     { "(" ~ chirality ~ atom ~ atom ~ atom ~ atom ~ ")" }
 brick_baked =
-    { "(" ~ "baked" ~ joint_baked+ ~ (push_baked | pull_baked)+ ~ (left_baked | right_baked)+ ~ ")" }
+    { "(" ~ "baked" ~ joint_baked+ ~ interval_baked+ ~ face_baked+ ~ ")" }
 joint_baked = // x, y, z
     { "(" ~ "joint" ~ float ~ float ~ float ~ ")" }
-push_baked = // alpha_index, omega_index, strain
-    { "(" ~ "push" ~ integer ~ integer ~ float ~ ")" }
-pull_baked = // alpha_index, omega_index, strain
-    { "(" ~ "pull" ~ integer ~ integer ~ float ~ ")" }
-left_baked = // a, b, c, name
-    { "(" ~ "left" ~ integer ~ integer ~ integer ~ atom ~ ")" }
-right_baked = // a, b, c, name
-    { "(" ~ "right" ~ integer ~ integer ~ integer ~ atom ~ ")" }
+interval_baked = // alpha_index, omega_index, strain
+    { "(" ~ interval_role ~ integer ~ integer ~ float ~ ")" }
+interval_role = { push | pull }
+push = { "push" }
+pull = { "pull" }
+face_baked = // a, b, c, name
+    { "(" ~ chirality ~ integer ~ integer ~ integer ~ atom ~ ")" }
 
 face_name = @{"F" ~ integer}
 ident = @{ XID_START ~ (XID_CONTINUE | "-")* }

--- a/src/controls/mod.rs
+++ b/src/controls/mod.rs
@@ -14,7 +14,7 @@ use winit::window::{CursorIcon, Window};
 #[cfg(target_arch = "wasm32")]
 use instant::Instant;
 
-use crate::build::tenscript::FabricPlan;
+use crate::build::tenscript::{Collection, FabricPlan};
 use crate::controls::fabric_choice::{FabricChoice, FabricChoiceMessage};
 use crate::controls::gravity::{Gravity, GravityMessage};
 use crate::controls::strain_threshold::{StrainThreshold, StrainThresholdMessage};
@@ -217,7 +217,8 @@ pub struct ControlState {
 
 impl Default for ControlState {
     fn default() -> Self {
-        let choices = FabricPlan::bootstrap()
+        let choices = Collection::bootstrap()
+            .fabrics
             .into_iter()
             .map(|plan| plan.name)
             .collect();

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -1,6 +1,6 @@
 use cgmath::Vector3;
 
-use crate::build::brick::{Brick, BrickName};
+use crate::build::brick::{Baked, BrickName};
 use crate::build::tenscript::FabricPlan;
 use crate::build::tenscript::plan_runner::PlanRunner;
 use crate::experiment::Stage::{*};
@@ -116,7 +116,7 @@ impl Experiment {
                 let age = self.fabric.age;
                 if age > 1000 && speed_squared < 1e-12 {
                     println!("Fabric settled in iteration {age} at speed squared {speed_squared}");
-                    match Brick::try_from((self.fabric.clone(), *face_id)) {
+                    match Baked::try_from((self.fabric.clone(), *face_id)) {
                         Ok(brick) => {
                             println!("{}", brick.into_code());
                         }
@@ -161,7 +161,7 @@ impl Experiment {
 
     pub fn capture_prototype(&mut self, brick_name: BrickName) {
         println!("Settling and capturing prototype {brick_name:?}");
-        self.stage = AcceptingPrototype(Brick::prototype(brick_name));
+        self.stage = AcceptingPrototype(Baked::prototype(brick_name));
     }
 
     fn start_pretensing(&mut self) {

--- a/src/fabric/brick.rs
+++ b/src/fabric/brick.rs
@@ -1,6 +1,6 @@
 use cgmath::{EuclideanSpace, Point3, Transform, Vector3};
 
-use crate::build::brick::{Brick, BrickName};
+use crate::build::brick::{Baked, BrickName};
 use crate::build::tenscript::FaceName;
 use crate::fabric::{Fabric, Link, UniqueId};
 use crate::fabric::face::Face;
@@ -15,7 +15,7 @@ impl Fabric {
     pub fn attach_brick(&mut self, brick_name: BrickName, scale_factor: f32, face_id: Option<UniqueId>) -> Vec<(FaceName, UniqueId)> {
         let face = face_id.map(|id| self.face(id));
         let scale = face.map(|Face { scale, .. }| *scale).unwrap_or(1.0) * scale_factor;
-        let brick = Brick::new(brick_name);
+        let brick = Baked::new(brick_name);
         let matrix = face.map(|face| face.vector_space(self, true));
         let joints: Vec<usize> = brick.joints
             .into_iter()
@@ -42,7 +42,7 @@ impl Fabric {
                 let alpha_index = self.create_joint(Point3::from_vec(midpoint));
                 let radial_intervals = brick_joints.map(|omega| {
                     let omega_index = joints[omega];
-                    let ideal = self.ideal(alpha_index, omega_index, Brick::TARGET_FACE_STRAIN);
+                    let ideal = self.ideal(alpha_index, omega_index, Baked::TARGET_FACE_STRAIN);
                     self.create_interval(alpha_index, omega_index, Link::pull(ideal))
                 });
                 (face_name, self.create_face(face_name, scale, spin, radial_intervals))


### PR DESCRIPTION
Parse bricks, prototype and baked, from tenscript. Introduce new top-level collection rule that includes both fabric plans and bricks

TODO: 
1. support String face names
2. validate the names used in a brick proto (maybe?)
3. bake the brick prototypes and insert the baked bricks into bootstrap.scm
4. port the code to use Tenscript bricks instead of the old Rusty bricks
